### PR TITLE
remove empty string from permission array

### DIFF
--- a/src/ios/FacebookConnectPlugin.m
+++ b/src/ios/FacebookConnectPlugin.m
@@ -202,7 +202,11 @@
 {    
     NSArray *permissions = nil;
     if ([command.arguments count] > 0) {
-        permissions = command.arguments;
+        // sanitize permissions array
+        // remove empty strings
+        permissions = [command.arguments filteredArrayUsingPredicate:[NSPredicate predicateWithBlock:^BOOL(id evaluatedObject, NSDictionary *bindings) {
+            return ![evaluatedObject isEqual:@""];
+        }]];
     }
     
     // save the callbackId for the login callback


### PR DESCRIPTION
I experienced login problem with iOS native Facebook settings. As I mentioned https://github.com/phonegap/phonegap-facebook-plugin/issues/368#issuecomment-27459354, it can be resolved by setting empty array for `permissions`.
